### PR TITLE
Update build:browser script to update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "git@github.com:uphold/uphold-sdk-javascript.git",
   "scripts": {
     "build": "rm -rf dist && yarn build:node && yarn build:browser",
-    "build:browser": "webpack --progress",
+    "build:browser": "yarn && webpack --progress",
     "build:node": "babel src/node -d dist/node && babel src/core -d dist/core",
     "changelog": "github-changelog-generator --owner uphold --repo uphold-sdk-javascript --future-release=v$npm_package_version > CHANGELOG.md",
     "cover": "yarn test -- --coverage",


### PR DESCRIPTION
#### Description

This PR adds a `yarn` command to the **build:browser** script to ensure all dependencies are updated when bundling the browser distribution file.