### PR TITLE
Add otp argument to .updateMe()

### DIFF
--- a/docs/actions/user/update-me.md
+++ b/docs/actions/user/update-me.md
@@ -2,9 +2,12 @@
 
 Updates the authenticated user's details.
 
+The `otp` argument will add the `OTP-TOKEN` header to the request.
+
 | Argument  | Type   | Required | Description                                              |
 |:----------|:-------|:---------|:---------------------------------------------------------|
 | `body`    | Object | Yes      | Request body                                             |
+| `otp`     | String | No       | OTP token                                                |
 | `options` | Object | No       | Any options you may want to pass to [`.api()`](/sdk#api) |
 
 The `body` argument accepts the following keys:

--- a/src/core/actions/user.js
+++ b/src/core/actions/user.js
@@ -4,8 +4,8 @@ export function getMe(options) {
   return this.api('/me', options);
 }
 
-export function updateMe({ address, birthdate, country, firstName, identity, lastName, settings, state, username }, options) {
-  return this.api('/me', merge({
+export function updateMe({ address, birthdate, country, firstName, identity, lastName, settings, state, username }, otp, options) {
+  options = merge({
     body: {
       address,
       birthdate,
@@ -18,5 +18,14 @@ export function updateMe({ address, birthdate, country, firstName, identity, las
       username
     },
     method: 'patch'
-  }, options));
+  }, options);
+
+  if (otp) {
+    options.headers = {
+      'otp-token': otp,
+      ...options.headers
+    };
+  }
+
+  return this.api('/me', options);
 }

--- a/test/core/actions/user.spec.js
+++ b/test/core/actions/user.spec.js
@@ -29,7 +29,7 @@ describe('UserActions', () => {
         settings: 'qex',
         state: 'qix',
         username: 'qox'
-      }, { fiz: 'faz' })
+      }, false, { fiz: 'faz' })
         .then(result => {
           expect(result).toBe('foo');
           expect(sdk.api).toBeCalledWith('/me', {
@@ -45,6 +45,29 @@ describe('UserActions', () => {
               username: 'qox'
             },
             fiz: 'faz',
+            method: 'patch'
+          });
+        });
+    });
+
+    it('should make a request to `PATCH /me` with otp', () => {
+      return sdk.updateMe({
+        address: 'bar'
+      }, 'biz', {
+        headers: {
+          baz: 'buz'
+        }
+      })
+        .then(result => {
+          expect(result).toBe('foo');
+          expect(sdk.api).toBeCalledWith('/me', {
+            body: {
+              address: 'bar'
+            },
+            headers: {
+              baz: 'buz',
+              'otp-token': 'biz'
+            },
             method: 'patch'
           });
         });


### PR DESCRIPTION
#### Description

This PR adds the `otp` argument to the `.updateMe()` action, which is required when disabling one of user’s OTP settings.