### PR TITLE
Add destination argument to createCardTransation action method

### DIFF
--- a/docs/actions/card-transaction/create-card-transaction.md
+++ b/docs/actions/card-transaction/create-card-transaction.md
@@ -16,12 +16,13 @@ The `commit` argument will add the `commit` query parameter.
 
 The `body` argument accepts the following keys:
 
-| Key            | Type   | Description                                                  |
-|:---------------|:-------|:-------------------------------------------------------------|
-| `amount`       | String | The value amount to send in the denominated currency         |
-| `currency`     | String | The currency by which you wish to denominate the transaction |
-| `message`      | String | Transaction details                                          |
-| `securityCode` | String | Credit card security code                                    |
+| Key            | Type   | Description                                                                                                                                                 |
+|:---------------|:-------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`       | String | The value amount to send in the denominated currency                                                                                                        |
+| `currency`     | String | The currency by which you wish to denominate the transaction                                                                                                |
+| `destination`  | String | The destination of the transaction, which can be in the form of a bitcoin address, an email address, an account id, an application id or an Uphold username |
+| `message`      | String | Transaction details                                                                                                                                         |
+| `securityCode` | String | Credit card security code                                                                                                                                   |
 
 This method returns a **Promise**.
 

--- a/src/core/actions/card-transaction.js
+++ b/src/core/actions/card-transaction.js
@@ -28,13 +28,14 @@ export function commitCardTransaction(cardId, transactionId, { message, security
 }
 
 // eslint-disable-next-line max-params
-export function createCardTransaction(cardId, { amount, currency, message, securityCode }, commit, otp, options) {
+export function createCardTransaction(cardId, { amount, currency, destination, message, securityCode }, commit, otp, options) {
   options = merge({
     body: {
       denomination: {
         amount,
         currency
       },
+      destination,
       message,
       securityCode
     },

--- a/test/core/actions/card-transaction.spec.js
+++ b/test/core/actions/card-transaction.spec.js
@@ -55,7 +55,7 @@ describe('CardTransactionActions', () => {
 
   describe('createCardTransaction()', () => {
     it('should make a request to `POST /me/cards/:cardId/transactions`', () => {
-      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', message: 'buz', securityCode: 'bez' }, false, false, { qux: 'qix' })
+      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', destination: 'qax', message: 'buz', securityCode: 'bez' }, false, false, { qux: 'qix' })
         .then(result => {
           expect(result).toBe('foo');
           expect(sdk.api).toBeCalledWith('/me/cards/bar/transactions', {
@@ -64,6 +64,7 @@ describe('CardTransactionActions', () => {
                 amount: 'biz',
                 currency: 'baz'
               },
+              destination: 'qax',
               message: 'buz',
               securityCode: 'bez'
             },
@@ -74,7 +75,7 @@ describe('CardTransactionActions', () => {
     });
 
     it('should make a request to `POST /me/cards/:cardId/transactions` with commit query paramameter', () => {
-      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', message: 'buz', securityCode: 'bez' }, true, false, { queryParams: { qux: 'qix' } })
+      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', destination: 'qax', message: 'buz', securityCode: 'bez' }, true, false, { queryParams: { qux: 'qix' } })
         .then(result => {
           expect(result).toBe('foo');
           expect(sdk.api).toBeCalledWith('/me/cards/bar/transactions', {
@@ -83,6 +84,7 @@ describe('CardTransactionActions', () => {
                 amount: 'biz',
                 currency: 'baz'
               },
+              destination: 'qax',
               message: 'buz',
               securityCode: 'bez'
             },


### PR DESCRIPTION
#### Description

This PR adds the `destination` argument to the `.createCardTransaction()` method, which is mandatory.