### PR TITLE
Fix `getToken()` method

### DIFF
--- a/src/core/sdk.js
+++ b/src/core/sdk.js
@@ -70,6 +70,12 @@ export default class SDK {
   getToken() {
     return this.storage.getItem(this.options.accessTokenKey)
       .then(access_token => {
+        if (!access_token) {
+          this.tokenRequestPromise = null;
+
+          return Promise.reject();
+        }
+
         return this.storage.getItem(this.options.refreshTokenKey)
           .then(refresh_token => ({
             access_token,


### PR DESCRIPTION
#### Description

This PR fixes the response of the `getToken()`. In some cases the method is returning a promise to request the token and it should return an `AuthorizationRequiredError`. 

