### PR TITLE
Allow for passing body that is already stringified

### DIFF
--- a/src/core/sdk.js
+++ b/src/core/sdk.js
@@ -39,7 +39,9 @@ export default class SDK {
     let request;
 
     if (body) {
-      body = JSON.stringify(body);
+      if (typeof body === 'object') {
+        body = JSON.stringify(body);
+      }
       headers['content-type'] = 'application/json';
     }
 

--- a/test/core/sdk.spec.js
+++ b/test/core/sdk.spec.js
@@ -450,6 +450,16 @@ describe('SDK', () => {
         });
     });
 
+    it('should pass a stringified body without modification', () => {
+      const newCard = JSON.stringify({ currency: 'foo', label: 'bar' });
+
+      return sdk.api('/biz', { body: newCard, method: 'post' })
+        .then(() => {
+          expect(sdk.client.request.mock.calls.length).toBe(1);
+          expect(sdk.client.request.mock.calls[0][2]).toBe(newCard);
+        });
+    });
+
     it('should return the full response if `raw` option is provided', () => {
       sdk.client.request.mockReturnValue(Promise.resolve('foo'));
 


### PR DESCRIPTION
#### Description

This PR allows passing a body that already had `JSON.stringify` run on it. This enables use cases where a digest header needs to be sent as it is important to ensure that the body sent matches up exactly with the body used to generate the digest header.