### PR TITLE
Add entire response object on each request response

### DIFF
--- a/src/browser/services/fetch-client.js
+++ b/src/browser/services/fetch-client.js
@@ -27,12 +27,12 @@ export default class FetchClient extends Client {
       })
       .catch(error => {
         if (!error.json) {
-          return Promise.reject(createError(this._formatResponse({ error, status: -1 })));
+          return Promise.reject(createError(this._formatResponse({ error, status: -1 }), error));
         }
 
         return error.text()
           .then(this._parseText)
-          .then(body => Promise.reject(createError(this._formatResponse(error, body))));
+          .then(body => Promise.reject(createError(this._formatResponse(error, body), error)));
       });
   }
 

--- a/src/core/utils/error-factory.js
+++ b/src/core/utils/error-factory.js
@@ -1,9 +1,9 @@
 import errors from '../errors';
 
-export function createError(response) {
+export function createError(error, response) {
   for (const SDKError of errors) {
-    if (SDKError.hasError && SDKError.hasError(response)) {
-      return new SDKError(response);
+    if (SDKError.hasError && SDKError.hasError(error)) {
+      return new SDKError({ ...error, response });
     }
   }
 }

--- a/src/node/services/request-client.js
+++ b/src/node/services/request-client.js
@@ -16,7 +16,7 @@ export default class RequestClient extends Client {
       url
     })
       .then(response => this._formatResponse(response))
-      .catch(response => Promise.reject(response instanceof RequestError ? response : createError(this._formatResponse(response.response))));
+      .catch(response => Promise.reject(response instanceof RequestError ? response : createError(this._formatResponse(response.response), response)));
   }
 
   _formatResponse({ body, headers, statusCode }) {

--- a/test/core/utils/error-factory.spec.js
+++ b/test/core/utils/error-factory.spec.js
@@ -53,5 +53,12 @@ describe('ErrorFactory', () => {
     it('should create a `ValidationFailedError`', () => {
       expect(createError({ body: { code: 'validation_failed' } })).toBeInstanceOf(ValidationFailedError);
     });
+
+    it('should create add an `response` attribute when provided', () => {
+      const error = createError({ status: 403 }, { foo: 'bar' });
+
+      expect(error).toBeInstanceOf(ForbiddenError);
+      expect(error.response).toEqual({ foo: 'bar' });
+    });
   });
 });


### PR DESCRIPTION
#### Description

This PR adds the entire request response to the provided object. This will be more useful for failed requests, making it easier to debug what went wrong for that request. 

#### Related issues

- Relates #10 
