### PR TITLE
Update cookie definition to use root path

### DIFF
--- a/src/browser/services/cookie-storage.js
+++ b/src/browser/services/cookie-storage.js
@@ -54,6 +54,6 @@ export default class CookieStorage {
   }
 
   _setCookie(data) {
-    document.cookie = `${this.storageName}=${encodeURIComponent(JSON.stringify(data))}`;
+    document.cookie = `${this.storageName}=${encodeURIComponent(JSON.stringify(data))};path=/`;
   }
 }


### PR DESCRIPTION
This PR updates the `setCookie` method to always use root path when creating a cookie. 