### PR TITLE
bump request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "content-range": "1.1.0",
     "lodash.merge": "4.6.0",
     "qs": "6.4.0",
-    "request": "2.81.0",
+    "request": "2.86.0",
     "request-promise": "4.2.0",
     "standard-error": "1.1.0",
     "text-encoding": "0.6.4"


### PR DESCRIPTION
#### Description

request `2.81.0` pulls in `hoek@2.16.3`, which is flagged by an nsp advisory:
https://nodesecurity.io/advisories/566

dep chain:
`@uphold/uphold-sdk-javascript@2.2.0 > request@2.81.0 > hawk@3.1.3 > hoek@2.16.3`

this appears to be solved by bumping the version of `request` used