### PR TITLE
Add priority to create card transaction

### DIFF
--- a/src/core/actions/card-transaction.js
+++ b/src/core/actions/card-transaction.js
@@ -28,7 +28,7 @@ export function commitCardTransaction(cardId, transactionId, { message, security
 }
 
 // eslint-disable-next-line max-params
-export function createCardTransaction(cardId, { amount, currency, destination, origin, message, securityCode }, commit, otp, options) {
+export function createCardTransaction(cardId, { amount, currency, destination, message, origin, priority, securityCode }, commit, otp, options) {
   options = merge({
     body: {
       denomination: {
@@ -38,6 +38,7 @@ export function createCardTransaction(cardId, { amount, currency, destination, o
       destination,
       message,
       origin,
+      priority,
       securityCode
     },
     method: 'post'

--- a/test/core/actions/card-transaction.spec.js
+++ b/test/core/actions/card-transaction.spec.js
@@ -55,7 +55,7 @@ describe('CardTransactionActions', () => {
 
   describe('createCardTransaction()', () => {
     it('should make a request to `POST /me/cards/:cardId/transactions`', () => {
-      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', destination: 'qax', message: 'buz', origin: 'bad', securityCode: 'bez' }, false, false, { qux: 'qix' })
+      return sdk.createCardTransaction('bar', { amount: 'biz', currency: 'baz', destination: 'qax', message: 'buz', origin: 'bad', priority: 'boz', securityCode: 'bez' }, false, false, { qux: 'qix' })
         .then(result => {
           expect(result).toBe('foo');
           expect(sdk.api).toBeCalledWith('/me/cards/bar/transactions', {
@@ -67,6 +67,7 @@ describe('CardTransactionActions', () => {
               destination: 'qax',
               message: 'buz',
               origin: 'bad',
+              priority: 'boz',
               securityCode: 'bez'
             },
             method: 'post',


### PR DESCRIPTION
This PR adds the support for a `priority` field when creating card transactions.