### PR TITLE
Add scope and otp header to storage

### DIFF
--- a/src/core/errors/otp-required.js
+++ b/src/core/errors/otp-required.js
@@ -1,4 +1,5 @@
 import { BaseError } from './base';
+import { includes } from 'lodash';
 
 export class OTPRequiredError extends BaseError {
   static hasError({ headers } = {}) {
@@ -6,7 +7,7 @@ export class OTPRequiredError extends BaseError {
       return false;
     }
 
-    return headers['otp-token'].toUpperCase() === 'REQUIRED';
+    return includes(['OPTIONAL', 'REQUIRED'], headers['otp-token'].toUpperCase());
   }
 
   constructor() {

--- a/test/core/sdk.spec.js
+++ b/test/core/sdk.spec.js
@@ -252,17 +252,19 @@ describe('SDK', () => {
       sdk.storage = { setItem: jest.fn(() => Promise.resolve()) };
     });
 
-    it('should store both access and refresh tokens', () => {
-      return sdk.setToken({ access_token: 'foo', refresh_token: 'bar' })
+    it('should store both access and refresh tokens, otp-token header and scope', () => {
+      return sdk.setToken({ access_token: 'foo', refresh_token: 'bar', scope: 'read' }, { 'otp-token': 'required' })
         .then(() => {
           expect(sdk.storage.setItem.mock.calls).toEqual([
             ['uphold.access_token', 'foo'],
+            ['uphold.scope', 'read'],
+            ['uphold.otp_token_status', 'required'],
             ['uphold.refresh_token', 'bar']
           ]);
         });
     });
 
-    it('should not set refresh_token if not provided', () => {
+    it('should not set refresh_token, scope or otp-token header if not provided', () => {
       return sdk.setToken({ access_token: 'foo' })
         .then(() => {
           expect(sdk.storage.setItem).toBeCalledWith('uphold.access_token', 'foo');


### PR DESCRIPTION
#### Description

This PR adds scope and otp-token header to storage to allow the user to recover 2fa by email when he's not logged in on the mobile app.
