### PR TITLE
Remove user-agent default header

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -35,9 +35,7 @@ export default class extends SDK {
 
 ```json
 {
-  "defaultHeaders": {
-    "user-agent": "uphold-sdk-javascript/<version>"
-  }
+  "defaultHeaders": {}
 }
 ```
 

--- a/src/core/services/client.js
+++ b/src/core/services/client.js
@@ -1,7 +1,5 @@
-import { name, version } from '../../../package.json';
-
 export default class Client {
   constructor() {
-    this.defaultHeaders = { 'user-agent': `${name}/${version}` };
+    this.defaultHeaders = {};
   }
 }

--- a/test/browser/services/fetch-client.spec.js
+++ b/test/browser/services/fetch-client.spec.js
@@ -1,5 +1,4 @@
 import { FetchClient, NotFoundError, UnavailableError } from '../../../src/browser';
-import { version } from '../../../package.json';
 import fetchMock from 'fetch-mock';
 
 describe('FetchClient', () => {
@@ -16,15 +15,6 @@ describe('FetchClient', () => {
       return client.request('foo')
         .then(() => {
           expect(fetchMock.lastOptions().method).toEqual('GET');
-        });
-    });
-
-    it('should send a `User-Agent` header', () => {
-      fetchMock.mock('foo', {});
-
-      return client.request('foo')
-        .then(() => {
-          expect(fetchMock.lastOptions().headers.get('user-agent')).toBe(`@uphold/uphold-sdk-javascript/${version}`);
         });
     });
 

--- a/test/core/services/client.spec.js
+++ b/test/core/services/client.spec.js
@@ -1,10 +1,9 @@
 import { Client } from '../../../src/core';
-import { name, version } from '../../../package.json';
 
 describe('Client', () => {
   describe('constructor()', () => {
     it('should set `defaultHeaders` property', () => {
-      expect(new Client().defaultHeaders).toEqual({ 'user-agent': `${name}/${version}` });
+      expect(new Client().defaultHeaders).toEqual({});
     });
   });
 });


### PR DESCRIPTION
#### Description

This PR removes (even if temporarily) the default `user-agent` header. This was causing access issues in both Safari and Firefox mainly due to such header not being listed on the `Access-Control-Allow-Headers` property. 

