### PR TITLE
Release 2.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v2.4.5](https://github.com/uphold/uphold-sdk-javascript/releases/tag/v2.4.5) (2026-05-11)
+- Bump yarn to v4 [\#77](https://github.com/uphold/uphold-sdk-javascript/pull/77) ([xavi-999](https://github.com/xavi-999))
+
 ## [v2.4.4](https://github.com/uphold/uphold-sdk-javascript/releases/tag/v2.4.4) (2021-01-13)
 - Add password field to updateMe [\#46](https://github.com/uphold/uphold-sdk-javascript/pull/46) ([hitmanmcc](https://github.com/hitmanmcc))
 - Add release task [\#47](https://github.com/uphold/uphold-sdk-javascript/pull/47) ([hitmanmcc](https://github.com/hitmanmcc))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uphold/uphold-sdk-javascript",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Uphold SDK for JavasScript",
   "keywords": [
     "api",


### PR DESCRIPTION
## [v2.4.5](https://github.com/uphold/uphold-sdk-javascript/releases/tag/v2.4.5) (2026-05-11)
- Bump yarn to v4 [\#77](https://github.com/uphold/uphold-sdk-javascript/pull/77) ([xavi-999](https://github.com/xavi-999))